### PR TITLE
Remove unused event StopAsync.cs

### DIFF
--- a/AngularLanguageService/AngularLanguageClient.cs
+++ b/AngularLanguageService/AngularLanguageClient.cs
@@ -38,7 +38,6 @@ namespace AngularLanguageService
         public IEnumerable<string> FilesToWatch => null;
 
         public event AsyncEventHandler<EventArgs> StartAsync;
-        public event AsyncEventHandler<EventArgs> StopAsync;
 
         public object MiddleLayer { get; }
 


### PR DESCRIPTION
Fixes analyzer warning CS0067 "The event 'AngularLanguageClient.StopAsync' is never used"