### PR TITLE
Update language service version and @angular/language-server dependency to v19

### DIFF
--- a/AngularLanguageService.2022/package-lock.json
+++ b/AngularLanguageService.2022/package-lock.json
@@ -1,20 +1,20 @@
 {
     "name": "AngularLanguageService.2022",
-    "lockfileVersion": 2,
+    "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "dependencies": {
-                "@angular/language-server": "17.0.0",
-                "typescript": "5.2.2"
+                "@angular/language-server": "19.0.3",
+                "typescript": "5.6.2"
             }
         },
         "node_modules/@angular/language-server": {
-            "version": "17.0.0",
-            "resolved": "https://registry.npmjs.org/@angular/language-server/-/language-server-17.0.0.tgz",
-            "integrity": "sha512-oXO6F1Cy7UVTadFV3bBAbhbCnz3W1tpMo3Ga78bM/P9yfZg+CwhhjROmxPsl1y9FtoWdUTDWHRjVuYXaFfOVGQ==",
+            "version": "19.0.3",
+            "resolved": "https://registry.npmjs.org/@angular/language-server/-/language-server-19.0.3.tgz",
+            "integrity": "sha512-fsxstCZw56pMKACXlQdNzFmnV5Pzj3CynW8CK3026Kj93oggXzqY55EciyuspNocNqtm1OOZXhCM/fTKzzJwdQ==",
             "dependencies": {
-                "@angular/language-service": "17.0.0-rc.3",
+                "@angular/language-service": "19.0.1",
                 "vscode-html-languageservice": "^4.2.5",
                 "vscode-jsonrpc": "6.0.0",
                 "vscode-languageserver": "7.0.0",
@@ -25,21 +25,21 @@
                 "ngserver": "bin/ngserver"
             },
             "engines": {
-                "node": "^18.13.0 || >=20.0.0"
+                "node": "^18.19.1 || ^20.11.1"
             }
         },
         "node_modules/@angular/language-service": {
-            "version": "17.0.0-rc.3",
-            "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-17.0.0-rc.3.tgz",
-            "integrity": "sha512-F2LZUr9Kpeuz8Lqnm/KHxJMWX51+f2DzIPBNOVkNdgcTyQGXlQdJJBznpQ2QwaRaNP30Oz6/hOyAy95SKaVKSg==",
+            "version": "19.0.1",
+            "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-19.0.1.tgz",
+            "integrity": "sha512-1gpC3oYaD3kcOg7lElZId70wz9SSD/mYDDq6UFn0XGX7HXcmxdFQFxEmYil/7aUHU7mhju0Bse7cAsSdm1vL+w==",
             "engines": {
-                "node": "^18.13.0 || >=20.9.0"
+                "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
             }
         },
         "node_modules/typescript": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+            "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -50,9 +50,8 @@
         },
         "node_modules/vscode-html-languageservice": {
             "version": "4.2.5",
-            "resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/Intellicode/npm/registry/vscode-html-languageservice/-/vscode-html-languageservice-4.2.5.tgz",
-            "integrity": "sha1-wMyP89gk0WOIu6wYfhgodJ7M8AY=",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-4.2.5.tgz",
+            "integrity": "sha512-dbr10KHabB9EaK8lI0XZW7SqOsTfrNyT3Nuj0GoPi4LjGKUmMiLtsqzfedIzRTzqY+w0FiLdh0/kQrnQ0tLxrw==",
             "dependencies": {
                 "vscode-languageserver-textdocument": "^1.0.4",
                 "vscode-languageserver-types": "^3.16.0",
@@ -88,106 +87,30 @@
                 "vscode-languageserver-types": "3.16.0"
             }
         },
-        "node_modules/vscode-languageserver-textdocument": {
-            "version": "1.0.8",
-            "resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/Intellicode/npm/registry/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-            "integrity": "sha1-nq6UUJy9lF6kS8qNz+S7DBW7OsA=",
-            "license": "MIT"
-        },
-        "node_modules/vscode-languageserver-types": {
+        "node_modules/vscode-languageserver-protocol/node_modules/vscode-languageserver-types": {
             "version": "3.16.0",
             "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
             "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+        },
+        "node_modules/vscode-languageserver-textdocument": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
         },
         "node_modules/vscode-nls": {
             "version": "5.2.0",
-            "resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/Intellicode/npm/registry/vscode-nls/-/vscode-nls-5.2.0.tgz",
-            "integrity": "sha1-PLaJPdm9aVJE2KAkvfdG7qZlzD8=",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+            "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="
         },
         "node_modules/vscode-uri": {
             "version": "3.0.7",
-            "resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/Intellicode/npm/registry/vscode-uri/-/vscode-uri-3.0.7.tgz",
-            "integrity": "sha1-bRn+84fua0bEeeX7AIcOFeWMHrg=",
-            "license": "MIT"
-        }
-    },
-    "dependencies": {
-        "@angular/language-server": {
-            "version": "17.0.0",
-            "resolved": "https://registry.npmjs.org/@angular/language-server/-/language-server-17.0.0.tgz",
-            "integrity": "sha512-oXO6F1Cy7UVTadFV3bBAbhbCnz3W1tpMo3Ga78bM/P9yfZg+CwhhjROmxPsl1y9FtoWdUTDWHRjVuYXaFfOVGQ==",
-            "requires": {
-                "@angular/language-service": "17.0.0-rc.3",
-                "vscode-html-languageservice": "^4.2.5",
-                "vscode-jsonrpc": "6.0.0",
-                "vscode-languageserver": "7.0.0",
-                "vscode-languageserver-textdocument": "^1.0.7",
-                "vscode-uri": "3.0.7"
-            }
-        },
-        "@angular/language-service": {
-            "version": "17.0.0-rc.3",
-            "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-17.0.0-rc.3.tgz",
-            "integrity": "sha512-F2LZUr9Kpeuz8Lqnm/KHxJMWX51+f2DzIPBNOVkNdgcTyQGXlQdJJBznpQ2QwaRaNP30Oz6/hOyAy95SKaVKSg=="
-        },
-        "typescript": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
-        },
-        "vscode-html-languageservice": {
-            "version": "4.2.5",
-            "resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/Intellicode/npm/registry/vscode-html-languageservice/-/vscode-html-languageservice-4.2.5.tgz",
-            "integrity": "sha1-wMyP89gk0WOIu6wYfhgodJ7M8AY=",
-            "requires": {
-                "vscode-languageserver-textdocument": "^1.0.4",
-                "vscode-languageserver-types": "^3.16.0",
-                "vscode-nls": "^5.0.0",
-                "vscode-uri": "^3.0.3"
-            }
-        },
-        "vscode-jsonrpc": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
-        },
-        "vscode-languageserver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-            "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
-            "requires": {
-                "vscode-languageserver-protocol": "3.16.0"
-            }
-        },
-        "vscode-languageserver-protocol": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
-            "requires": {
-                "vscode-jsonrpc": "6.0.0",
-                "vscode-languageserver-types": "3.16.0"
-            }
-        },
-        "vscode-languageserver-textdocument": {
-            "version": "1.0.8",
-            "resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/Intellicode/npm/registry/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-            "integrity": "sha1-nq6UUJy9lF6kS8qNz+S7DBW7OsA="
-        },
-        "vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-        },
-        "vscode-nls": {
-            "version": "5.2.0",
-            "resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/Intellicode/npm/registry/vscode-nls/-/vscode-nls-5.2.0.tgz",
-            "integrity": "sha1-PLaJPdm9aVJE2KAkvfdG7qZlzD8="
-        },
-        "vscode-uri": {
-            "version": "3.0.7",
-            "resolved": "https://devdiv.pkgs.visualstudio.com/_packaging/Intellicode/npm/registry/vscode-uri/-/vscode-uri-3.0.7.tgz",
-            "integrity": "sha1-bRn+84fua0bEeeX7AIcOFeWMHrg="
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
+            "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
         }
     }
 }

--- a/AngularLanguageService.2022/package.json
+++ b/AngularLanguageService.2022/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "@angular/language-server": "17.0.0",
-        "typescript": "5.2.2"
+        "@angular/language-server": "19.0.3",
+        "typescript": "5.6.2"
     }
 }

--- a/AngularLanguageService.2022/source.extension.vsixmanifest
+++ b/AngularLanguageService.2022/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="AngularLS.bf76f463-39ee-4ab1-91be-0f47c4b595ca" Version="1.1.7" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="AngularLS.bf76f463-39ee-4ab1-91be-0f47c4b595ca" Version="1.1.8" Language="en-US" Publisher="Microsoft" />
         <DisplayName>Angular Language Service 2022</DisplayName>
         <Description>Provides the Angular language service to enable editor features for Angular templates.</Description>
         <License>EULA.rtf</License>


### PR DESCRIPTION
…cy to v19

This commit updates the version of the extension as well as the dependencies.

The latest version of @angular/language-server is v19.0.3 and uses TypeScript 5.6.2.