### PR TITLE
Revert "Updated LanguageServerClient and WebTools"

### DIFF
--- a/AngularLanguageService.2022/AngularLanguageService.2022.csproj
+++ b/AngularLanguageService.2022/AngularLanguageService.2022.csproj
@@ -73,11 +73,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <!-- LSP dependencies -->
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="17.13.33" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="17.0.5158" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.0.5133" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.63" />
     <!-- For accessing WebTools' type definitions -->
-    <PackageReference Include="Microsoft.WebTools.Languages.Html.Editor" Version="17.6.339" />
+    <PackageReference Include="Microsoft.WebTools.Languages.Html.Editor" Version="17.0.633" />
     <!-- Some dependencies indirectly depend on older versions of Newtonsoft.Json so we explicitly set it here. -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>


### PR DESCRIPTION
Reverts microsoft/vs-ng-language-service#82

This change appears to have broken build. I'm reverting to get main working again and we will make un-revert once we have these changes working again.